### PR TITLE
Fix attachments for topics

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -49,6 +49,6 @@ class TopicsController < ApplicationController
   private
 
   def topic_params
-    params.require(:topic).permit(:title, :description, :category_id, :location_id, image:[])
+    params.require(:topic).permit(:title, :description, :category_id, :location_id, images: [])
   end
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -3,7 +3,7 @@ class Topic < ApplicationRecord
      belongs_to :category, optional: true
      belongs_to :location, optional: true
      
-     has_one_attached :images  
+     has_many_attached :images
      has_many :comments, dependent: :destroy
 
      validates :title, presence: true


### PR DESCRIPTION
## Summary
- allow multiple images for `Topic` attachments
- permit `images` in `TopicsController`

## Testing
- `bundle exec rake test` *(fails: Could not find gems)*

------
https://chatgpt.com/codex/tasks/task_e_684813eaba388333a657cc6a0c116143